### PR TITLE
Bug fix for multiple configuration deployment on sync

### DIFF
--- a/controller/src/main/java/org/openremote/controller/deployer/Version20ModelBuilder.java
+++ b/controller/src/main/java/org/openremote/controller/deployer/Version20ModelBuilder.java
@@ -570,6 +570,11 @@ public class Version20ModelBuilder extends AbstractModelBuilder
       {
         controllerDefinitionIsPresent = true;
 
+        if (lastTimeStamp == 0)
+        {
+          lastTimeStamp = getControllerXMLTimeStamp();
+        }
+
         return true;
       }
     }

--- a/controller/src/main/java/org/openremote/controller/deployer/Version20ModelBuilder.java
+++ b/controller/src/main/java/org/openremote/controller/deployer/Version20ModelBuilder.java
@@ -306,14 +306,6 @@ public class Version20ModelBuilder extends AbstractModelBuilder
 
 
   /**
-   * Indicates whether the controller.xml for this schema implementation has been found.
-   *
-   * @see #hasControllerDefinitionChanged()
-   */
-  private boolean controllerDefinitionIsPresent;
-
-
-  /**
    * Last known timestamp of controller.xml file.
    */
   private long lastTimeStamp = 0L;
@@ -426,15 +418,6 @@ public class Version20ModelBuilder extends AbstractModelBuilder
 
     this.config = config;
 
-
-    // check for the required artifacts (XML document) are present to build the object model...
-
-    controllerDefinitionIsPresent = checkControllerDefinitionExists(config);
-
-    if (controllerDefinitionIsPresent)
-    {
-      lastTimeStamp = getControllerXMLTimeStamp();
-    }
   }
 
 
@@ -544,12 +527,11 @@ public class Version20ModelBuilder extends AbstractModelBuilder
    */
   @Override public boolean hasControllerDefinitionChanged()
   {
-    if (controllerDefinitionIsPresent)
+    if (lastTimeStamp > 0)
     {
       if (!checkControllerDefinitionExists(config))
       {
-        // it was there before, now it's gone...
-        controllerDefinitionIsPresent = false;
+        lastTimeStamp = 0;
 
         return true;
       }
@@ -558,8 +540,6 @@ public class Version20ModelBuilder extends AbstractModelBuilder
 
       if (lastModified > lastTimeStamp)
       {
-        lastTimeStamp = lastModified;
-
         return true;
       }
     }
@@ -568,13 +548,6 @@ public class Version20ModelBuilder extends AbstractModelBuilder
     {
       if (checkControllerDefinitionExists(config))
       {
-        controllerDefinitionIsPresent = true;
-
-        if (lastTimeStamp == 0)
-        {
-          lastTimeStamp = getControllerXMLTimeStamp();
-        }
-
         return true;
       }
     }
@@ -674,7 +647,11 @@ public class Version20ModelBuilder extends AbstractModelBuilder
         builder.setValidation(true);
       }
 
-      return builder.build(controllerXMLFile);
+      Document doc =  builder.build(controllerXMLFile);
+
+      lastTimeStamp = getControllerXMLTimeStamp();
+
+      return doc;
     }
 
     catch (Throwable t)

--- a/controller/src/main/java/org/openremote/controller/service/Deployer.java
+++ b/controller/src/main/java/org/openremote/controller/service/Deployer.java
@@ -1625,16 +1625,9 @@ public class Deployer
 
           if (deployer.modelBuilder == null || deployer.modelBuilder.hasControllerDefinitionChanged())
           {
-            boolean isUpdateChangedState = (deployer.modelBuilder == null);
-
             try
             {
               deployer.softRestart();
-
-              if (isUpdateChangedState && deployer.modelBuilder != null)
-              {
-                deployer.modelBuilder.hasControllerDefinitionChanged();
-              }
             }
 
             catch (ControllerDefinitionNotFoundException e)

--- a/controller/src/main/java/org/openremote/controller/service/Deployer.java
+++ b/controller/src/main/java/org/openremote/controller/service/Deployer.java
@@ -1625,9 +1625,16 @@ public class Deployer
 
           if (deployer.modelBuilder == null || deployer.modelBuilder.hasControllerDefinitionChanged())
           {
+            boolean isUpdateChangedState = (deployer.modelBuilder == null);
+
             try
             {
               deployer.softRestart();
+
+              if (isUpdateChangedState && deployer.modelBuilder != null)
+              {
+                deployer.modelBuilder.hasControllerDefinitionChanged();
+              }
             }
 
             catch (ControllerDefinitionNotFoundException e)


### PR DESCRIPTION
- Call `hasControllerDefinitionChanged()` in each iteration of the file watcher even if the model builder doesn't exist initially because this method has side effects.
- Set the `lastTimeStamp`value of the very first configuration file

@ebariaux could you review and test it with your configuration 
